### PR TITLE
add close to output file

### DIFF
--- a/vgmpacker.py
+++ b/vgmpacker.py
@@ -767,7 +767,9 @@ class VgmPacker:
 		self.report(lz4, data_block, output, 8, "Paired 8 register blocks [01][23][45][6][7][8][9][A] WITH register masks ")
 
 		# write the lz4 compressed file.
-		open(dst_filename, "wb").write( output )
+		fo = open(dst_filename, "wb")
+		fo.write( output )
+		fo.close()
 
 
 #------------------------------------------------------------------------


### PR DESCRIPTION
Add a call to close() on output file
It is mandatory when this script is called from javax.script (python), otherwise file may not be fully flushed.